### PR TITLE
Fix for ICanHaz breaking in IE

### DIFF
--- a/ICanHaz.js
+++ b/ICanHaz.js
@@ -66,7 +66,7 @@ var ich;
         $('script[type="text/html"]').each(function () {
             var script = $(this),
                 name = script.attr('id'),
-                text = script.html().trim(),
+                text = $.trim(script.html()),
                 isPartial = script.attr('class').toLowerCase() === 'partial';
             
             if (isPartial) {

--- a/test/test.html
+++ b/test/test.html
@@ -6,7 +6,7 @@
         <script src="../mustache.js"></script>
         <link rel="stylesheet" href="qunit/qunit.css" type="text/css" media="screen" />
         <script type="text/javascript" src="qunit/qunit.js"></script>
-        <script type="text/javascript" src="../ICanHaz.min.js"></script>
+        <script type="text/javascript" src="../ICanHaz.js"></script>
         <script type="text/javascript" src="./ich_test.js"></script>
         
         <!-- Testing templates -->


### PR DESCRIPTION
So, ICanHaz was failing in IE because the trim method used to trim the templates after they are retrieved from the script tags doesn't exist on the String object in IE.  I switched it to use jQuery's trim function instead.  All tests pass.
