### PR TITLE
Simple documentation change

### DIFF
--- a/index.html
+++ b/index.html
@@ -327,7 +327,7 @@ You just won ${{value}} (which is ${{taxed_value}} after tax)
             browsers. But basically, there's no reason it shouldn't
             work in any browser that jQuery and Mustache
             support. It should also work with Zepto in any browser 
-            Zepto which is a smaller list of course.</p>
+            Zepto supports which is a smaller list of course.</p>
 
             <ul>
                 <li>IE 6, 8 (and 8 in compat. mode, which is


### PR DESCRIPTION
Changed:

> It should also work with Zepto in any browser Zepto which is a smaller list of course.

to

> It should also work with Zepto in any browser Zepto **supports** which is a smaller list of course.

to improve readability.
