### PR TITLE
adding ajax-loading of remote templates.

### DIFF
--- a/ICanHaz.js
+++ b/ICanHaz.js
@@ -399,49 +399,49 @@ function ICanHaz() {
     //   'other/path/test.mustache'
     // ], callback);
     self.loadTemplates = function (templates, callback) {
-    	var loads = 0,
-    		names,
-    		title,
-    		basename = /([^\/]+)\.[^.]+$/;
+        var loads = 0,
+            names,
+            title,
+            basename = /([^\/]+)\.[^.]+$/;
 
-    	// enables String-Array-format for loading
-    	if (templates instanceof Array) {
-    		var i,
-    			l = templates.length;
+        // enables String-Array-format for loading
+        if (templates instanceof Array) {
+            var i,
+                l = templates.length;
 
-    		names = {};
-    		for (i = 0; i<l; i++) {
-    			title = templates[i].match(basename);
-    			names[title[1]] = templates[i];
-    		}
-    	} else {
-    		names = templates;
-    	}
+            names = {};
+            for (i = 0; i<l; i++) {
+                title = templates[i].match(basename);
+                names[title[1]] = templates[i];
+            }
+        } else {
+            names = templates;
+        }
 
-    	// handles loading of one url
-    	function loadNext(key, url) {
-    		$.ajax({
-    			url: url,
-    			success: function (data) {
-    				if (key[0] === '_') {
-    					ich.addPartial(key.substr(1), data);
-    				} else {
-    					ich.addTemplate(key, data);
-    				}
-    				if (--loads <= 0 && typeof(callback) === 'function') {callback();}
-    			},
-    			error: function (xhr, type) {
-    				if (--loads <= 0 && typeof(callback) === 'function') {callback();}
-    				throw 'error while loading '+url+': '+type;
-    			}
-    		});
-    	}
+        // handles loading of one url
+        function loadNext(key, url) {
+            $.ajax({
+                url: url,
+                success: function (data) {
+                    if (key[0] === '_') {
+                        ich.addPartial(key.substr(1), data);
+                    } else {
+                        ich.addTemplate(key, data);
+                    }
+                    if (--loads <= 0 && typeof(callback) === 'function') {callback();}
+                },
+                error: function (xhr, type) {
+                    if (--loads <= 0 && typeof(callback) === 'function') {callback();}
+                    throw 'error while loading '+url+': '+type;
+                }
+            });
+        }
 
-    	// kick off loading
-    	for (var key in names) {
-    		loads++;
-    		loadNext(key, names[key]);
-    	}
+        // kick off loading
+        for (var key in names) {
+            loads++;
+            loadNext(key, names[key]);
+        }
     };
 
     // clears all retrieval functions and empties caches

--- a/ICanHaz.js
+++ b/ICanHaz.js
@@ -377,6 +377,66 @@ function ICanHaz() {
         });
     };
     
+    // ajax-load external template files.
+    // you may specify either an array of urls (the templates
+    // will be available under their basenames) or specify
+    // an object (the templates will be available under the key-name).
+    //
+    // after successful loading, an optional callback will be called.
+    //
+    // ich.loadTemplates({
+    //   start:'js/templates/start.mustache',
+    //   test: 'other/path/test.mustache'
+    // }, callback);
+    //
+    // *OR*
+    //
+    // loadTemplates([
+    //   'javascripts/templates/start.mustache',
+    //   'other/path/test.mustache'
+    // ], callback);
+    self.loadTemplates = function (templates, callback) {
+    	var loads = 0,
+    		names,
+    		title,
+    		basename = /([^\/]+)\.[^.]+$/;
+
+    	// enables String-Array-format for loading
+    	if (templates instanceof Array) {
+    		var i,
+    			l = templates.length;
+
+    		names = {};
+    		for (i = 0; i<l; i++) {
+    			title = templates[i].match(basename);
+    			names[title[1]] = templates[i];
+    		}
+    	} else {
+    		names = templates;
+    	}
+
+    	// handles loading of one url
+    	function loadNext(key, url) {
+    		$.ajax({
+    			url: url,
+    			success: function (data) {
+    				ich.addTemplate(key, data);
+    				if (--loads <= 0 && typeof(callback) === 'function') {callback();}
+    			},
+    			error: function (xhr, type) {
+    				if (--loads <= 0 && typeof(callback) === 'function') {callback();}
+    				throw 'error while loading '+url+': '+type;
+    			}
+    		});
+    	}
+
+    	// kick off loading
+    	for (var key in names) {
+    		loads++;
+    		loadNext(key, names[key]);
+    	}
+    };
+
     // clears all retrieval functions and empties caches
     self.clearAll = function () {
         for (var key in self.templates) {

--- a/ICanHaz.js
+++ b/ICanHaz.js
@@ -381,8 +381,11 @@ function ICanHaz() {
     // you may specify either an array of urls (the templates
     // will be available under their basenames) or specify
     // an object (the templates will be available under the key-name).
+    // filenames with leading underscores will be interpreted as partial
+    // (inspired by rails' behaviour
     //
     // after successful loading, an optional callback will be called.
+    // this allows for lazy-loading of templates.
     //
     // ich.loadTemplates({
     //   start:'js/templates/start.mustache',
@@ -420,7 +423,11 @@ function ICanHaz() {
     		$.ajax({
     			url: url,
     			success: function (data) {
-    				ich.addTemplate(key, data);
+    				if (key[0] === '_') {
+    					ich.addPartial(key.substr(1), data);
+    				} else {
+    					ich.addTemplate(key, data);
+    				}
     				if (--loads <= 0 && typeof(callback) === 'function') {callback();}
     			},
     			error: function (xhr, type) {

--- a/source/main.js
+++ b/source/main.js
@@ -69,49 +69,49 @@ function ICanHaz() {
     //   'other/path/test.mustache'
     // ], callback);
     self.loadTemplates = function (templates, callback) {
-    	var loads = 0,
-    		names,
-    		title,
-    		basename = /([^\/]+)\.[^.]+$/;
+        var loads = 0,
+            names,
+            title,
+            basename = /([^\/]+)\.[^.]+$/;
 
-    	// enables String-Array-format for loading
-    	if (templates instanceof Array) {
-    		var i,
-    			l = templates.length;
+        // enables String-Array-format for loading
+        if (templates instanceof Array) {
+            var i,
+                l = templates.length;
 
-    		names = {};
-    		for (i = 0; i<l; i++) {
-    			title = templates[i].match(basename);
-    			names[title[1]] = templates[i];
-    		}
-    	} else {
-    		names = templates;
-    	}
+            names = {};
+            for (i = 0; i<l; i++) {
+                title = templates[i].match(basename);
+                names[title[1]] = templates[i];
+            }
+        } else {
+            names = templates;
+        }
 
-    	// handles loading of one url
-    	function loadNext(key, url) {
-    		$.ajax({
-    			url: url,
-    			success: function (data) {
-    				if (key[0] === '_') {
-    					ich.addPartial(key.substr(1), data);
-    				} else {
-    					ich.addTemplate(key, data);
-    				}
-    				if (--loads <= 0 && typeof(callback) === 'function') {callback();}
-    			},
-    			error: function (xhr, type) {
-    				if (--loads <= 0 && typeof(callback) === 'function') {callback();}
-    				throw 'error while loading '+url+': '+type;
-    			}
-    		});
-    	}
+        // handles loading of one url
+        function loadNext(key, url) {
+            $.ajax({
+                url: url,
+                success: function (data) {
+                    if (key[0] === '_') {
+                        ich.addPartial(key.substr(1), data);
+                    } else {
+                        ich.addTemplate(key, data);
+                    }
+                    if (--loads <= 0 && typeof(callback) === 'function') {callback();}
+                },
+                error: function (xhr, type) {
+                    if (--loads <= 0 && typeof(callback) === 'function') {callback();}
+                    throw 'error while loading '+url+': '+type;
+                }
+            });
+        }
 
-    	// kick off loading
-    	for (var key in names) {
-    		loads++;
-    		loadNext(key, names[key]);
-    	}
+        // kick off loading
+        for (var key in names) {
+            loads++;
+            loadNext(key, names[key]);
+        }
     };
 
     // clears all retrieval functions and empties caches

--- a/source/main.js
+++ b/source/main.js
@@ -51,8 +51,11 @@ function ICanHaz() {
     // you may specify either an array of urls (the templates
     // will be available under their basenames) or specify
     // an object (the templates will be available under the key-name).
+    // filenames with leading underscores will be interpreted as partial
+    // (inspired by rails' behaviour
     //
     // after successful loading, an optional callback will be called.
+    // this allows for lazy-loading of templates.
     //
     // ich.loadTemplates({
     //   start:'js/templates/start.mustache',
@@ -90,7 +93,11 @@ function ICanHaz() {
     		$.ajax({
     			url: url,
     			success: function (data) {
-    				ich.addTemplate(key, data);
+    				if (key[0] === '_') {
+    					ich.addPartial(key.substr(1), data);
+    				} else {
+    					ich.addTemplate(key, data);
+    				}
     				if (--loads <= 0 && typeof(callback) === 'function') {callback();}
     			},
     			error: function (xhr, type) {

--- a/source/main.js
+++ b/source/main.js
@@ -3,7 +3,37 @@
 */
 /*global jQuery  */
 function ICanHaz() {
-    var self = this;
+    var self = this,
+        activeSequence = 0,
+        pendingRequestCounter = 0,
+        loadingCallbacks = [],
+
+        // Firing all callbacks when calling grabTemplates repeatedly.
+        // eg. pre-load templates with:
+        // $(function () {ich.grabTemplates(function () {
+        //   ... all templates are now ready for use ...
+        // });})
+        finishedLoading = function () {
+            var callbacks = loadingCallbacks;
+            loadingCallbacks = [];
+            for (var i = 0; i < callbacks.length; i++) {
+                callbacks[i]();
+            }
+        },
+
+        // check the <script> tag for type and name of the template/partial
+        // if no ("id" attribute) is found then parse it from the "src" path
+        add = function (script, text) {
+            var type = script.hasClass('partial')
+                    ? 'addPartial'
+                    : 'addTemplate',
+                name = script.attr('id')
+                    || script.attr('src')
+                        .split(/[\\\/]/).pop() // chop directory path
+                        .split(/[\.\?\#]/).shift(); // chop extension, fragment, query
+            self[type](name, text);
+        };
+
     self.VERSION = "@VERSION@";
     self.templates = {};
     self.partials = {};
@@ -13,7 +43,7 @@ function ICanHaz() {
     // If you want a different template, it should have a different name.
     self.addTemplate = function (name, templateString) {
         if (self[name]) throw "Invalid name: " + name + ".";
-        if (self.templates[name]) throw "Template \" + name + \" exists";
+        if (self.templates[name]) throw "Template " + name + " exists";
         
         self.templates[name] = templateString;
         self[name] = function (data, raw) {
@@ -26,25 +56,58 @@ function ICanHaz() {
     // public function for adding partials
     self.addPartial = function (name, templateString) {
         if (self.partials[name]) {
-            throw "Partial \" + name + \" exists";
+            throw "Partial " + name + " exists";
         } else {
             self.partials[name] = templateString;
         }
     };
     
     // grabs templates from the DOM and caches them.
+    // Takes an optional callback function as argument that fires when all
+    // templates and partials have loaded (locally embedded and remote includes).
     // Loop through and add templates.
     // Whitespace at beginning and end of all templates inside <script> tags will 
     // be trimmed. If you want whitespace around a partial, add it in the parent, 
     // not the partial. Or do it explicitly using <br/> or &nbsp;
-    self.grabTemplates = function () {        
-        $('script[type="text/html"]').each(function (a, b) {
-            var script = $((typeof a === 'number') ? b : a), // Zepto doesn't bind this
+    self.grabTemplates = function (callback) {        
+        var embeddedTemplates = $('script[type="text/html"]:not([src])'),
+            remoteTemplates = $('script[type="text/html"][src]'),
+            requestSequence = activeSequence;
+
+        if (callback) loadingCallbacks.push(callback);
+
+        // parse templates embedded in <script> tags 
+        embeddedTemplates.each(function (a, b) {
+            var script = $((typeof a === 'number') ? b : a),
                 text = (''.trim) ? script.html().trim() : $.trim(script.html());
-            
-            self[script.hasClass('partial') ? 'addPartial' : 'addTemplate'](script.attr('id'), text);
+            add(script, text);
             script.remove();
         });
+
+        // fetch external templates specified via "src" attribute
+        pendingRequestCounter += remoteTemplates.length;
+        remoteTemplates.each(function (a, b) {
+            var script = $((typeof a === 'number') ? b : a);
+            script.detach();
+            $.ajax({url: script.prop('src'), dataType: 'text',
+                success: function (template) {
+                    if (requestSequence === activeSequence) {
+                        var text = (''.trim) ? template.trim() : $.trim(template);
+                        add(script, text);
+                    }
+                },
+                error: function () {
+                    throw "Failed to load remote template " + script.prop('src');
+                },
+                complete: function () {
+                    script.remove();
+                    if (requestSequence === activeSequence && --pendingRequestCounter === 0)
+                        finishedLoading();
+                }
+            });
+        });
+
+        if (pendingRequestCounter === 0) finishedLoading();
     };
     
     // ajax-load external template files.
@@ -115,17 +178,21 @@ function ICanHaz() {
     };
 
     // clears all retrieval functions and empties caches
+    // resets any previous callbacks
     self.clearAll = function () {
         for (var key in self.templates) {
             delete self[key];
         }
         self.templates = {};
         self.partials = {};
+        activeSequence++;
+        pendingRequestCounter = 0;
+        loadingCallbacks = [];
     };
     
-    self.refresh = function () {
+    self.refresh = function (callback) {
         self.clearAll();
-        self.grabTemplates();
+        self.grabTemplates(callback);
     };
 }
 

--- a/source/main.js
+++ b/source/main.js
@@ -47,6 +47,66 @@ function ICanHaz() {
         });
     };
     
+    // ajax-load external template files.
+    // you may specify either an array of urls (the templates
+    // will be available under their basenames) or specify
+    // an object (the templates will be available under the key-name).
+    //
+    // after successful loading, an optional callback will be called.
+    //
+    // ich.loadTemplates({
+    //   start:'js/templates/start.mustache',
+    //   test: 'other/path/test.mustache'
+    // }, callback);
+    //
+    // *OR*
+    //
+    // loadTemplates([
+    //   'javascripts/templates/start.mustache',
+    //   'other/path/test.mustache'
+    // ], callback);
+    self.loadTemplates = function (templates, callback) {
+    	var loads = 0,
+    		names,
+    		title,
+    		basename = /([^\/]+)\.[^.]+$/;
+
+    	// enables String-Array-format for loading
+    	if (templates instanceof Array) {
+    		var i,
+    			l = templates.length;
+
+    		names = {};
+    		for (i = 0; i<l; i++) {
+    			title = templates[i].match(basename);
+    			names[title[1]] = templates[i];
+    		}
+    	} else {
+    		names = templates;
+    	}
+
+    	// handles loading of one url
+    	function loadNext(key, url) {
+    		$.ajax({
+    			url: url,
+    			success: function (data) {
+    				ich.addTemplate(key, data);
+    				if (--loads <= 0 && typeof(callback) === 'function') {callback();}
+    			},
+    			error: function (xhr, type) {
+    				if (--loads <= 0 && typeof(callback) === 'function') {callback();}
+    				throw 'error while loading '+url+': '+type;
+    			}
+    		});
+    	}
+
+    	// kick off loading
+    	for (var key in names) {
+    		loads++;
+    		loadNext(key, names[key]);
+    	}
+    };
+
     // clears all retrieval functions and empties caches
     self.clearAll = function () {
         for (var key in self.templates) {

--- a/test/external_templates/_some_partial.mustache
+++ b/test/external_templates/_some_partial.mustache
@@ -1,0 +1,1 @@
+<em>awesome</em>

--- a/test/external_templates/no_partial.mustache
+++ b/test/external_templates/no_partial.mustache
@@ -1,0 +1,1 @@
+<p>I use my partials: {{>some_partial}}</p>

--- a/test/external_templates/test.mustache
+++ b/test/external_templates/test.mustache
@@ -1,0 +1,1 @@
+<p>The sole purpose is to demonstrate loading. If you insist i'll add a variable: {{var}}</p>

--- a/test/external_templates/weird-name.html
+++ b/test/external_templates/weird-name.html
@@ -1,0 +1,1 @@
+<p>Hello {{name}}, that's quite a weird name</p>

--- a/test/ich_test.js
+++ b/test/ich_test.js
@@ -60,7 +60,7 @@ test("renders partials added at runtime", function() {
         		return this.value - (this.value * 0.4);
     		}
   		}
-	}
+	};
 	equal(ich.welcome2(view, true), 'Welcome, Joe! You just won $1000 (which is $600 after tax)');
 });
 
@@ -98,4 +98,37 @@ test("refresh should empty then grab new", function () {
     equal(ich.hasOwnProperty('flint'), false, "flint template should be gone");
 });
 
+test("renders remotely loaded files from array notation", function () {
+	expect(4);
+	stop();
+	ich.loadTemplates(
+		['external_templates/test.mustache', 'external_templates/weird-name.html'], 
+		function () {
+			start();
+			ok(typeof(ich.test) !== 'undefined', 'should load template file test.mustache');
+			ok(typeof(ich['weird-name']) !== 'undefined', 'should load template file weird-name.html');
+			equal(ich.test({"var": "blurp"}, true), '<p>The sole purpose is to demonstrate loading. If you insist i\'ll add a variable: blurp</p>', 'should have rendered differently');
+			equal(ich['weird-name']({name: 'Guy'}, true), '<p>Hello Guy, that\'s quite a weird name</p>', 'should have rendered differently');
+		}
+	);
+});
 
+test("renders remotely loaded files from object notation", function () {
+	expect(6);
+	stop();
+	ich.loadTemplates(
+		{
+			awesome: 'external_templates/test.mustache', 
+			renaming: 'external_templates/weird-name.html'
+		},
+		function () {
+			start();
+			ok(typeof(ich.awesome) !== 'undefined', 'should load template file test.mustache');
+			ok(typeof(ich.renaming) !== 'undefined', 'should load template file weird-name.html');
+			ok(typeof(ich.test) !== 'undefined', 'should not contain anything');
+			ok(typeof(ich['weird-name']) !== 'undefined', 'should not contain anything');
+			equal(ich.awesome({"var": "blurp"}, true), '<p>The sole purpose is to demonstrate loading. If you insist i\'ll add a variable: blurp</p>', 'should have rendered differently');
+			equal(ich.renaming({name: 'Guy'}, true), '<p>Hello Guy, that\'s quite a weird name</p>', 'should have rendered differently');
+		}
+	);
+});

--- a/test/ich_test.js
+++ b/test/ich_test.js
@@ -116,6 +116,7 @@ test("renders remotely loaded files from array notation", function () {
 test("renders remotely loaded files from object notation", function () {
 	expect(6);
 	stop();
+	ich.clearAll();
 	ich.loadTemplates(
 		{
 			awesome: 'external_templates/test.mustache', 
@@ -125,8 +126,8 @@ test("renders remotely loaded files from object notation", function () {
 			start();
 			ok(typeof(ich.awesome) !== 'undefined', 'should load template file test.mustache');
 			ok(typeof(ich.renaming) !== 'undefined', 'should load template file weird-name.html');
-			ok(typeof(ich.test) !== 'undefined', 'should not contain anything');
-			ok(typeof(ich['weird-name']) !== 'undefined', 'should not contain anything');
+			ok(typeof(ich.test) === 'undefined', 'should not contain anything');
+			ok(typeof(ich['weird-name']) === 'undefined', 'should not contain anything');
 			equal(ich.awesome({"var": "blurp"}, true), '<p>The sole purpose is to demonstrate loading. If you insist i\'ll add a variable: blurp</p>', 'should have rendered differently');
 			equal(ich.renaming({name: 'Guy'}, true), '<p>Hello Guy, that\'s quite a weird name</p>', 'should have rendered differently');
 		}

--- a/test/ich_test.js
+++ b/test/ich_test.js
@@ -43,8 +43,18 @@ test("renders partials from &lt;script&gt; tags with class=\"partial\"", functio
         		return this.value - (this.value * 0.4);
     		}
   		}
-	}
+	};
 	equal(ich.welcome(view, true), "<p>Welcome, Joe! You just won $1000 (which is $600 after tax)</p>");
+});
+
+test("loads script-tags with sources", function () {
+	stop();
+	// out of lack for a better way to delay this, i use a timeout.
+	setTimeout(function () {
+		start();
+		ok(typeof(ich.tag_with_id) !== 'undefined', 'should load template file script_tag_reference.html and store it under the specified id without us doing anything');
+		ok(typeof(ich.script_tag_reference) !== 'undefined', 'should load template file script_tag_reference.html and store it under its basename without us doing anything');
+	}, 300);
 });
 
 test("renders partials added at runtime", function() {

--- a/test/ich_test.js
+++ b/test/ich_test.js
@@ -133,3 +133,21 @@ test("renders remotely loaded files from object notation", function () {
 		}
 	);
 });
+
+test("loads files with leading underscore as partials", function () {
+	expect(5);
+	stop();
+	ich.clearAll();
+	ich.loadTemplates(
+		['external_templates/_some_partial.mustache', 'external_templates/no_partial.mustache'], 
+		function () {
+			start();
+			ok(typeof(ich.no_partial) !== 'undefined', 'should load template file no_partial.mustache');
+			ok(typeof(ich.some_partial) === 'undefined', 'should load template file some_partial.mustache, but not add it to the functions');
+			ok(typeof(ich._some_partial) === 'undefined', 'should load template file some_partial.mustache, but not add it to the functions, not even with leading underscore');
+			ok(typeof(ich.partials.some_partial) !== 'undefined', 'there should be a partial called "some_partial"');
+			equal(ich.no_partial({}, true), '<p>I use my partials: <em>awesome</em></p>', 'should render from the two files');
+		}
+	);
+});
+

--- a/test/test.html
+++ b/test/test.html
@@ -5,7 +5,7 @@
         <link rel="stylesheet" href="qunit/qunit.css" type="text/css" media="screen" />
         <script src="jquery-1.4.4.min.js"></script>
         <script src="qunit/qunit.js"></script>
-        <script src="../ICanHaz.min.js"></script>
+        <script src="../ICanHaz.js"></script>
         <script src="./ich_test.js"></script>
         
         <!-- Testing templates -->

--- a/test/test.html
+++ b/test/test.html
@@ -24,7 +24,10 @@
         <script id="version" type="text/html">
             ICanHaz Tests? YES! You're testing v{{ version }}
         </script>
-        
+
+        <script type="text/html" src="external_templates/script_tag_reference.html"></script>
+        <script id="tag_with_id" type="text/html" src="external_templates/script_tag_reference.html"></script>
+
         <script>
             // write build version to header
             $(function () {


### PR DESCRIPTION
Hey there,

for a project of mine, we needed to load templates on demand.
This introduces the loadTemplates() api, including unit-tests. We based our work off of v0.9.

it achieves a similar functionality to cbas' loading of external files. (https://github.com/andyet/ICanHaz.js/pull/16). His functionality could easily be implemented on top of this commit.

I included unit tests, in case you're curious, If you have any questions don't hesitate to ask!
