### PR TITLE
Stop leaking `l` into global scope.

### DIFF
--- a/ICanHaz.js
+++ b/ICanHaz.js
@@ -501,7 +501,7 @@ var Mustache = function () {
         // be trimmed. If you want whitespace around a partial, add it in the parent, 
         // not the partial. Or do it explicitly using <br/> or &nbsp;
         grabTemplates: function () {        
-            var i, 
+            var i, l,
                 scripts = document.getElementsByTagName('script'), 
                 script,
                 trash = [];


### PR DESCRIPTION
It's created during a loop but wasn't `var`ed up.
