### PR TITLE
Adds a workaround for missing addEventListener in IE8

### DIFF
--- a/ICanHaz.js
+++ b/ICanHaz.js
@@ -533,9 +533,17 @@ var Mustache = function () {
                 ich.grabTemplates();
             });
         } else {
-            document.addEventListener('DOMContentLoaded', function () {
+            var grabTemplateWrapper = function () {
                 ich.grabTemplates();
-            }, true);
+            }
+
+            // added as per http://stackoverflow.com/questions/1695376/msie-and-addeventlistener-problem-in-javascript
+            // to fix IE8 breakage.
+            if (document.addEventListener){
+                document.addEventListener('DOMContentLoaded', grabTemplateWrapper, true);
+            } else if (document.attachEvent){
+                document.attachEvent('DOMContentLoaded', grabTemplateWrapper);
+            }
         }
     }
         


### PR DESCRIPTION
For me this was not working in IE8, throwing an `Object doesn't support this property or method` error. 

According to http://stackoverflow.com/questions/1695376/msie-and-addeventlistener-problem-in-javascript, that's because IE8 doesn't implement addEventListener, which is used on [line 536](https://github.com/HenrikJoreteg/ICanHaz.js/blob/master/ICanHaz.js#L536).

I implemented the workaround suggested on that Stack Overflow question, and the error went away. I only changed the pre-minified code.
