### PR TITLE
Removed reference to ich.addPartial from the docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,9 +206,8 @@ You just won ${{value}} (which is ${{taxed_value}} after tax)
             <h3>Adding templates/partials later</h3>
 
             <p>Optionally, you can call <code>ich.addTemplate(name,
-            templateString)</code> or <code>ich.addPartial(name,
             templateString)</code> to add templates and partials if
-            you'd prefer to pull the from a server with ajax or
+            you'd prefer to pull them from a server with ajax or
             whatnot. You can even do <code>ich.grabTemplates</code>
             if you've loaded in some other page</p>
             


### PR DESCRIPTION
The ich.addPartial function no longer exists but was still found in the docs.

Signed-off-by: Adriaan Labuschagne adriaanlabuschagne@gmail.com
