### PR TITLE
Use new repository urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": "http://icanhazjs.com",
   "repository": {
     "type": "git",
-    "url": "git://github.com/andyet/ICanHaz.js.git"
+    "url": "git://github.com/HenrikJoreteg/ICanHaz.js.git"
   },
   "author": {
     "name": "Henrik Joreteg",
@@ -14,7 +14,7 @@
   "description": "Simple & powerful js templating tool",
   "licenses": [{
     "type": "MIT",
-    "url": "https://github.com/andyet/ICanHaz.js/blob/master/LICENSE"
+    "url": "https://github.com/HenrikJoreteg/ICanHaz.js/blob/master/LICENSE"
   }],
   "main": "ICanHaz.js",
   "keywords": [


### PR DESCRIPTION
The repository is made a link on [npmjs.org](https://www.npmjs.org/package/icanhaz) and should direct developers to this repo.
